### PR TITLE
fix a small typo in workspace url example

### DIFF
--- a/lib/hackpad/cli/workspace.rb
+++ b/lib/hackpad/cli/workspace.rb
@@ -20,7 +20,7 @@ module Hackpad
         puts Paint['Gather your information from https://<workspace>.hackpad.com/ep/account/settings/', :bold]
         values['client_id'] = guess 'HPCLI_CLIENTID', 'What is your Client ID?'
         values['secret'] = guess 'HPCLI_SECRET', 'What is your Secret Key?'
-        values['site'] = guess('HPCLI_URL', 'What is the URI of your workspace? (ex. https://xxx.hackapd.com)').gsub(/\/$/, '')
+        values['site'] = guess('HPCLI_URL', 'What is the URI of your workspace? (ex. https://xxx.hackpad.com)').gsub(/\/$/, '')
         write values
       end
 


### PR DESCRIPTION
hackapd.com -> hackpad.com
